### PR TITLE
Correct open window slot counter

### DIFF
--- a/src/main/java/com/telenordigital/sms/smpp/OutboundPduHandler.java
+++ b/src/main/java/com/telenordigital/sms/smpp/OutboundPduHandler.java
@@ -33,9 +33,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class OutboundPduHandler extends MessageToMessageCodec<ResponsePdu, RequestResponse<ResponsePdu>> {
+
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  private final AtomicInteger openWindowSlots;
   private final int windowSize;
   private final int timeoutSeconds;
 
@@ -47,7 +47,6 @@ class OutboundPduHandler extends MessageToMessageCodec<ResponsePdu, RequestRespo
       throw new IllegalArgumentException("Window size must be > 0");
     }
 
-    this.openWindowSlots = new AtomicInteger(windowSize);
     this.windowSize = windowSize;
     this.timeoutSeconds = timeoutSeconds;
   }
@@ -72,7 +71,8 @@ class OutboundPduHandler extends MessageToMessageCodec<ResponsePdu, RequestRespo
   }
 
   int getOpenWindowSlots() {
-    return openWindowSlots.get();
+    // this method will be called on a different thread. it is used only for monitoring purpose
+    return windowSize - window.size();
   }
 
   @Override
@@ -88,7 +88,6 @@ class OutboundPduHandler extends MessageToMessageCodec<ResponsePdu, RequestRespo
       msg.completeExceptionally(ctx, "Window is full");
     } else {
       window.put(request.sequenceNumber(), msg);
-      openWindowSlots.decrementAndGet();
       LOG.debug("Sending request: {}. Window size: {}", msg, window.size());
       out.add(request);
     }
@@ -103,7 +102,6 @@ class OutboundPduHandler extends MessageToMessageCodec<ResponsePdu, RequestRespo
       return;
     }
 
-    openWindowSlots.incrementAndGet();
     rr.complete(ctx, msg);
     out.add(msg);
 

--- a/src/main/java/com/telenordigital/sms/smpp/OutboundPduHandler.java
+++ b/src/main/java/com/telenordigital/sms/smpp/OutboundPduHandler.java
@@ -28,7 +28,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Make open window slot counter use the window map directly to obtain a snapshot of the current number of items
This should fix a potential issue with miss calculation of number of open connections