### PR TITLE
Use UTF_16BE instead of plain UTF_16 for UCS-2 encoding

### DIFF
--- a/src/main/java/com/telenordigital/sms/smpp/pdu/SubmitSm.java
+++ b/src/main/java/com/telenordigital/sms/smpp/pdu/SubmitSm.java
@@ -109,7 +109,7 @@ public record SubmitSm(
         throw new IllegalArgumentException("Message contents is outside the BMP");
       }
     }
-    return StandardCharsets.UTF_16;
+    return StandardCharsets.UTF_16BE;
   }
 
   @Override

--- a/src/test/java/com/telenordigital/sms/smpp/pdu/PduTest.java
+++ b/src/test/java/com/telenordigital/sms/smpp/pdu/PduTest.java
@@ -20,6 +20,7 @@ package com.telenordigital.sms.smpp.pdu;
  * #L%
  */
 
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
 
@@ -27,6 +28,16 @@ public class PduTest {
   protected static String serialize(final Pdu pdu) {
     final var buf = Unpooled.buffer();
     pdu.serialize(buf);
+    return serialize(buf);
+  }
+
+  protected static String serialize(final ByteArray byteArray) {
+    final var buf = Unpooled.buffer();
+    buf.writeBytes(byteArray.array());
+    return serialize(buf);
+  }
+
+  private static String serialize(final ByteBuf buf) {
     final var length = buf.readableBytes();
     final var bytes = new byte[length];
     buf.readBytes(bytes);

--- a/src/test/java/com/telenordigital/sms/smpp/pdu/SubmitSmTest.java
+++ b/src/test/java/com/telenordigital/sms/smpp/pdu/SubmitSmTest.java
@@ -30,6 +30,20 @@ import org.junit.jupiter.api.Test;
 
 public class SubmitSmTest extends PduTest {
   @Test
+  public void testBom() {
+    final var pdu =
+        SubmitSm.create(
+            Clock.systemUTC(),
+            "40404",
+            "44951361920",
+            "6718 e vashiat PIN for 360VRTUBE - седмичен абонамент. Ne go spodelqite.",
+            null);
+    final var msg = pdu.encodedShortMessage();
+    final var hex = serialize(msg);
+    assertThat(hex).doesNotStartWith("feff");
+  }
+
+  @Test
   public void testSerialize() {
     Sequencer.sequence.set(20456);
     final var pdu = SubmitSm.create(Clock.systemUTC(), "40404", "44951361920", "¡¤#!%&/:", null);

--- a/src/test/java/com/telenordigital/sms/smpp/pdu/SubmitSmTest.java
+++ b/src/test/java/com/telenordigital/sms/smpp/pdu/SubmitSmTest.java
@@ -32,12 +32,7 @@ public class SubmitSmTest extends PduTest {
   @Test
   public void testBom() {
     final var pdu =
-        SubmitSm.create(
-            Clock.systemUTC(),
-            "40404",
-            "44951361920",
-            "6718 e vashiat PIN for 360VRTUBE - седмичен абонамент. Ne go spodelqite.",
-            null);
+        SubmitSm.create(Clock.systemUTC(), "40404", "44951361920", "седмичен абонамент", null);
     final var msg = pdu.encodedShortMessage();
     final var hex = serialize(msg);
     assertThat(hex).doesNotStartWith("feff");


### PR DESCRIPTION
UTF_16 will add a BOM to the encoded string, which can cause problems for other SMPP servers. UTF_16BE explicitly uses big-endian encoding, and does not include a BOM.

The SMPP spec states that big-endian encoding should be used.