### PR TITLE
Parse command status in bind responses

### DIFF
--- a/src/main/java/com/telenordigital/sms/smpp/SmppConnection.java
+++ b/src/main/java/com/telenordigital/sms/smpp/SmppConnection.java
@@ -145,7 +145,7 @@ class SmppConnection implements Closeable {
           stateChange(SmppState.ACTIVE);
           LOG.info("Successfully bound to: {}", config.systemId());
         } else {
-          LOG.warn("Invalid bind response status: {}", bindResp.commandStatus());
+          LOG.warn("Invalid bind response status: {}", bindResp.status());
           ctx.channel().close();
         }
       }

--- a/src/main/java/com/telenordigital/sms/smpp/pdu/BindResp.java
+++ b/src/main/java/com/telenordigital/sms/smpp/pdu/BindResp.java
@@ -21,6 +21,10 @@ package com.telenordigital.sms.smpp.pdu;
  */
 
 import io.netty.buffer.ByteBuf;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 public record BindResp(
     Command command, int commandStatus, int sequenceNumber, String systemId, short interfaceVersion)
@@ -34,5 +38,34 @@ public record BindResp(
         PduUtil.readOptionalParams(buf).getByte(TlvTag.SC_INTERFACE_VERSION).orElse((byte) 0);
 
     return new BindResp(command, status, sequence, systemId, version);
+  }
+
+  public String status() {
+    return Optional.ofNullable(BindRespStatus.ALL.get(commandStatus))
+        .map(BindRespStatus::toString)
+        .orElse("UNKNOWN[0x%02X]".formatted(commandStatus));
+  }
+
+  private enum BindRespStatus {
+    OK(0x00),
+    ALREADY_BOUND(0x05),
+    SYSTEM_ERROR(0x08),
+    BIND_FAILED(0x0d),
+    INVALID_PASSWORD(0x0e),
+    INVALID_SYSTEM_ID(0x0f);
+
+    private static final Map<Integer, BindRespStatus> ALL =
+        EnumSet.allOf(BindRespStatus.class).stream().collect(Collectors.toMap(s -> s.code, s -> s));
+
+    private final int code;
+
+    BindRespStatus(final int code) {
+      this.code = code;
+    }
+
+    @Override
+    public String toString() {
+      return "%s[0x%02X]".formatted(name(), code);
+    }
   }
 }

--- a/src/test/java/com/telenordigital/sms/smpp/pdu/BindRespTest.java
+++ b/src/test/java/com/telenordigital/sms/smpp/pdu/BindRespTest.java
@@ -60,6 +60,7 @@ public class BindRespTest {
     assertThat(resp.systemId()).isEqualTo("twitter");
     assertThat(resp.sequenceNumber()).isEqualTo(235874);
     assertThat(resp.commandStatus()).isEqualTo(0);
+    assertThat(resp.status()).isEqualTo("OK[0x00]");
     assertThat(resp.interfaceVersion()).isEqualTo((byte) 0x34);
   }
 
@@ -69,7 +70,18 @@ public class BindRespTest {
     final byte[] bytes = ByteBufUtil.decodeHexDump(encoded);
     final var buf = Unpooled.copiedBuffer(bytes);
     buf.readBytes(8);
-    BindResp.deserialize(Command.BIND_RECEIVER_RESP, buf);
+    final var resp = BindResp.deserialize(Command.BIND_RECEIVER_RESP, buf);
+    assertThat(resp.status()).isEqualTo("BIND_FAILED[0x0D]");
+  }
+
+  @Test
+  public void bindFailedUnknownError() {
+    final var encoded = "00000010800000090000001d00000001";
+    final byte[] bytes = ByteBufUtil.decodeHexDump(encoded);
+    final var buf = Unpooled.copiedBuffer(bytes);
+    buf.readBytes(8);
+    final var resp = BindResp.deserialize(Command.BIND_RECEIVER_RESP, buf);
+    assertThat(resp.status()).isEqualTo("UNKNOWN[0x1D]");
   }
 
   @Test


### PR DESCRIPTION
To quickly recognize invalid password or similar problems in the logs.