### PR TITLE
Log bind errors as warnings

### DIFF
--- a/src/main/java/com/telenordigital/sms/smpp/SmppConnection.java
+++ b/src/main/java/com/telenordigital/sms/smpp/SmppConnection.java
@@ -131,7 +131,7 @@ class SmppConnection implements Closeable {
           .addListener(
               future -> {
                 if (!future.isSuccess()) {
-                  LOG.error("Error sending bind", future.cause());
+                  LOG.warn("Error sending bind", future.cause());
                   ctx.close();
                 }
               });


### PR DESCRIPTION
Instead of error, as it is probably not our fault.