### PR TITLE
Fix long messages with UDH and unicode

### DIFF
--- a/src/main/java/com/telenordigital/sms/smpp/pdu/SubmitSm.java
+++ b/src/main/java/com/telenordigital/sms/smpp/pdu/SubmitSm.java
@@ -146,8 +146,7 @@ public record SubmitSm(
   record MessagePart(int index, byte[] message) {}
 
   static List<MessagePart> splitMessage(final byte[] encodedShortMessage, final int maxBytes) {
-    // UDH is 6 bytes, but for unknown reasons we need to leave one byte unused
-    final int maxBytesExcludingUdh = maxBytes - 7;
+    final int maxBytesExcludingUdh = maxBytes - 6;
     final int msgCount = 1 + (encodedShortMessage.length / maxBytesExcludingUdh);
 
     return IntStream.range(0, msgCount)


### PR DESCRIPTION
Messages that need to be split, being sent to an SMSC that needs UDH splitting of messagess, were previously being split the wrong way.

We only allocated an odd number of bytes for each part, which does not fit well with UCS, which has two bytes per character. That is now fixed, so there's an even number of characters in each part.