### PR TITLE
Do not update the ch-smpp restcom dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       - "agavrilov76"
       - "madsholden"
     ignore:
-      - depencency-name: ch-smpp
+      - depencency-name: org.restcomm.smpp:ch-smpp
     groups:
       patches:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     reviewers:
       - "agavrilov76"
       - "madsholden"
+    ignore:
+      - depencency-name: ch-smpp
     groups:
       patches:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       - "agavrilov76"
       - "madsholden"
     ignore:
-      - depencency-name: org.restcomm.smpp:ch-smpp
+      - depencency-name: "org.restcomm.smpp:ch-smpp"
     groups:
       patches:
         update-types:


### PR DESCRIPTION
The library is linked to an expired domain, which means someone could take over this domain to publish malicious updates. We are only using it as a test dependency, and it hasn't received updates since 2018, so we can ignore any updates.